### PR TITLE
Remove changelog from modinfo

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -5,14 +5,7 @@ description = [[Version: ]] .. version .. "\n\n" ..
     [[By default, Shift +  (LMB) on the player or supported entities to keep following. Shift ]] ..
     [[+ Ctrl +  (LMB) to keep pushing.]] .. "\n\n" ..
     [[You can also use the above key combinations on a Tent/Siesta Lean-to used by another ]] ..
-    [[player to keep following or pushing him.]] .. "\n\n" ..
-
-    [[v]] .. version .. [[:]] .. "\n" ..
-    [[- Added compatibility configuration]] .. "\n" ..
-    [[- Changed following configurations]] .. "\n" ..
-    [[- Improved interruptions behaviour]] .. "\n" ..
-    [[- Improved keybinds configurations]] .. "\n" ..
-    [[- Improved mouse overrides]]
+    [[player to keep following or pushing him.]]
 author = "Depressed DST Modders"
 api_version = 10
 forumthread = ""
@@ -263,13 +256,6 @@ configuration_options = {
     --
 
     AddSection("Other"),
-
-    AddBooleanConfig(
-        "hide_changelog",
-        "Hide changelog",
-        [[When enabled, hides the changelog in the mod description.]] .. "\n" ..
-            [[Mods should be reloaded to take effect]]
-    ),
 
     AddBooleanConfig(
         "debug",

--- a/modmain.lua
+++ b/modmain.lua
@@ -329,10 +329,3 @@ SDK.OnLoadComponent("playercontroller", function(_self, player)
         end
     end
 end)
-
---- KnownModIndex
--- @section knownmodindex
-
-if GetModConfigData("hide_changelog") then
-    SDK.ModMain.HideChangelog(true)
-end


### PR DESCRIPTION
Closes #9.

- Remove changelog from `modinfo`
- Remove the "Hide changelog" configuration